### PR TITLE
[Trudy/Fix/#60]  알람 토글 끄면 노티가 안오도록 수정 완료

### DIFF
--- a/RudyMark/RudyMark/Models/NotificationModel.swift
+++ b/RudyMark/RudyMark/Models/NotificationModel.swift
@@ -6,7 +6,7 @@
 //
 import SwiftUI
 
-enum NotificationType: String, CaseIterable, Identifiable {
+enum NotificationType: String, CaseIterable, Identifiable, Codable {
     case bloodSugar = "혈당 알림"
     case meal = "식사 알림"
     case medication = "복약 알림"
@@ -21,7 +21,7 @@ enum NotificationType: String, CaseIterable, Identifiable {
     var id: String { rawValue }
 }
 
-struct NotificationTime: Identifiable, Equatable {
+struct NotificationTime: Identifiable, Equatable, Codable {
     let id: UUID
     var hour: Int
     var minute: Int

--- a/RudyMark/RudyMark/ViewModels/NotiViewmodels/NotificationTimeListViewModel.swift
+++ b/RudyMark/RudyMark/ViewModels/NotiViewmodels/NotificationTimeListViewModel.swift
@@ -10,7 +10,11 @@ import Foundation
 
 class NotificationTimeListViewModel: ObservableObject {
     @Published var times: [NotificationTime] = []
-
+    
+    init() {
+        load()
+    }
+    
     func times(for type: NotificationType) -> [NotificationTime] {
         times.filter { $0.type == type }
     }
@@ -23,8 +27,14 @@ class NotificationTimeListViewModel: ObservableObject {
     }
     
     func toggle(_ id: UUID) {
-        if let index = times.firstIndex(where: { $0.id == id }) {
-            times[index].isOn.toggle()
+        guard let index = times.firstIndex(where: { $0.id == id }) else { return }
+        times[index].isOn.toggle()
+        
+        let time = times[index]
+        if time.isOn {
+            LocalNotificationManager.shared.scheduleNotification(for: time, type: time.type)
+        } else {
+            LocalNotificationManager.shared.removeNotification(id: time.id)
         }
     }
     func add(time: NotificationTime) {
@@ -32,7 +42,7 @@ class NotificationTimeListViewModel: ObservableObject {
         times.append(time)
         printAll()
     }
-
+    
     func update(_ time: NotificationTime) {
         print("✅ update() 호출됨: \(time.formattedTime)")
         if let index = times.firstIndex(where: { $0.id == time.id }) {
@@ -42,11 +52,30 @@ class NotificationTimeListViewModel: ObservableObject {
             times.append(time)
         }
         printAll()
+        save()
     }
-
+    
     func delete(_ id: UUID) {
         print("✅ delete() 호출됨")
         times.removeAll { $0.id == id }
         printAll()
+        save()
+    }
+    
+    private let storageKey = "savedNotificationTimes"
+    
+    func save() {
+        if let data = try? JSONEncoder().encode(times) {
+            UserDefaults.standard.set(data, forKey: storageKey)
+            print("✅ 알림 목록 저장 완료")
+        }
+    }
+    
+    func load() {
+        if let data = UserDefaults.standard.data(forKey: storageKey),
+           let decoded = try? JSONDecoder().decode([NotificationTime].self, from: data) {
+            times = decoded
+            print("✅ 알림 목록 불러오기 완료")
+        }
     }
 }

--- a/RudyMark/RudyMark/Views/More/MorePages/AlarmListView.swift
+++ b/RudyMark/RudyMark/Views/More/MorePages/AlarmListView.swift
@@ -33,7 +33,18 @@ struct AlarmListView: View {
             }
 
             Button {
-                editingTime = NotificationTime(id: UUID(), hour: 9, minute: 0, isOn: true, type: type)
+                let now = Date()
+                let components = Calendar.current.dateComponents([.hour, .minute], from: now)
+                let hour = components.hour ?? 9
+                let minute = components.minute ?? 0
+                
+                editingTime = NotificationTime(
+                    id: UUID(),
+                    hour: hour,
+                    minute: minute,
+                    isOn: true,
+                    type: type
+                )
             } label: {
                 Label("알림 추가", systemImage: "plus")
             }


### PR DESCRIPTION
## 문제 상황
알람 토글을 끄게 되면 알람이 오지 않도록 해야하는데 여전히 오는 문제 발생

## 해결 방법
toggle이 on/off인지에 따라 등록하거나 삭제를 진행함
```
func toggle(_ id: UUID) {
    guard let index = times.firstIndex(where: { $0.id == id }) else { return }
    times[index].isOn.toggle()

    let time = times[index]
    if time.isOn {
        LocalNotificationManager.shared.scheduleNotification(for: time, type: time.type)
    } else {
        LocalNotificationManager.shared.removeNotification(id: time.id)
    }
}
```

## 추가 수정 사항
- 알람 시간을 맞출 때 현재 시간을 기준으로 맞추도록 하여 테스트 환경 개선(ex. 현재 시각이 오후 9시 46분일 경우 알림을 추가하려고 하면 시간 set이 09:46 PM 으로 뜸)

## 시뮬레이터
해당 부분은 Notification 관련 이슈로 휴대폰에서 앱을 돌려야 하는데 PR 작성시 업로드 가능한 크기인 10MB를 초과하여 첨부가 불가함을 알려드리며 양해 부탁드립니당..